### PR TITLE
update repository link in Cargo.toml to new subfolder

### DIFF
--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -4,7 +4,7 @@ description = "Read a beets music database"
 version = "0.1.0"
 authors = ["George Kaplan <george@georgekaplan.xyz>"]
 edition = "2018"
-repository = "https://github.com/g-s-k/berts/tree/master/beet-db"
+repository = "https://github.com/g-s-k/berts/tree/master/db"
 readme = "./README.md"
 license = "MIT"
 


### PR DESCRIPTION
The repository link for the `0.1.0` version published to crates.io points to the old subfolder.

After quickly editing this in github (hence the unintended trailing newline) I realized the last edit was 6 years ago, whoops.

I'm leaving this PR here just in case a `0.2.0` is made a some point